### PR TITLE
[Docs] Update README with local dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,3 @@ code --folder-uri "vscode-remote://dev-container+$(pwd)"
 ```
 
 The container exposes port `3000` to run the Next.js server.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.

--- a/tests/components.test.ts
+++ b/tests/components.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { Header } from '../src/app/components';
+
+describe('component exports', () => {
+  it('re-exports Header', () => {
+    expect(Header).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Context
The README still contained the default Next.js template. New instructions were needed to reflect project usage.

## Changes
- added project overview
- added yarn-based development, lint, test and build commands
- retained dev container notes

## Testing Done
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_687ff5955af4832699dbd1548f3aada9

## Summary by Sourcery

Update README to replace default Next.js template with project-specific overview and Yarn-based local development instructions

Documentation:
- Add project overview describing the Karakeep Home Portal and its tech stack
- Provide local development setup steps using Yarn
- List common scripts for linting, testing, and production build
- Retain existing Dev Container notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README with a new project title and description.
  * Simplified local development instructions and removed alternative commands.
  * Added a new section detailing available scripts for linting, testing, and production.
  * Removed outdated notes and clarified browser access instructions.
* **Tests**
  * Added a new test to verify the Header component is correctly exported and defined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->