### PR TITLE
[Feat] Add bookmark list homepage

### DIFF
--- a/src/app/components/BookmarkList.tsx
+++ b/src/app/components/BookmarkList.tsx
@@ -1,0 +1,37 @@
+import React, { HTMLAttributes } from "react";
+
+export interface Bookmark {
+  /** Display title */
+  title: string;
+  /** Bookmark URL */
+  url: string;
+  /** Visit count */
+  visits: number;
+}
+
+export interface BookmarkListProps extends HTMLAttributes<HTMLUListElement> {
+  /** List of bookmarks to display */
+  bookmarks: Bookmark[];
+}
+
+/**
+ * Display bookmarks as an accessible list.
+ */
+export default function BookmarkList({ bookmarks, ...rest }: BookmarkListProps) {
+  return (
+    <ul className="space-y-1" {...rest}>
+      {bookmarks.map(bookmark => (
+        <li key={bookmark.url}>
+          <a
+            href={bookmark.url}
+            className="text-blue-600 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {bookmark.title} ({bookmark.visits})
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/app/components/BookmarkList.tsx
+++ b/src/app/components/BookmarkList.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes } from "react";
+import React, { type HTMLAttributes } from "react";
 
 export interface Bookmark {
   /** Display title */

--- a/src/app/components/index.ts
+++ b/src/app/components/index.ts
@@ -1,2 +1,3 @@
 export { default as Header } from './Header';
+export { default as BookmarkList } from './BookmarkList';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,21 @@
-import Image from "next/image";
+import { Header, BookmarkList } from "./components";
+
+interface Bookmark {
+  title: string;
+  url: string;
+  visits: number;
+}
+
+const bookmarks: Bookmark[] = [
+  { title: "Karakeep Docs", url: "https://example.com/docs", visits: 42 },
+  { title: "GitHub Repo", url: "https://github.com", visits: 15 },
+];
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <main className="p-6 space-y-8">
+      <Header title="Portal" />
+      <BookmarkList bookmarks={bookmarks} className="space-y-2" />
+    </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,5 @@
 import { Header, BookmarkList } from "./components";
-
-interface Bookmark {
-  title: string;
-  url: string;
-  visits: number;
-}
+import type { Bookmark } from "./components/BookmarkList";
 
 const bookmarks: Bookmark[] = [
   { title: "Karakeep Docs", url: "https://example.com/docs", visits: 42 },

--- a/tests/BookmarkList.test.tsx
+++ b/tests/BookmarkList.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import BookmarkList from '../src/app/components/BookmarkList';
+
+describe('BookmarkList', () => {
+  it('renders provided bookmarks', () => {
+    const bookmarks = [
+      { title: 'Docs', url: 'https://docs', visits: 1 },
+      { title: 'Repo', url: 'https://repo', visits: 2 },
+    ];
+    render(<BookmarkList bookmarks={bookmarks} />);
+    expect(screen.getByRole('link', { name: 'Docs (1)' }).getAttribute('href')).toBe('https://docs');
+    expect(screen.getByRole('link', { name: 'Repo (2)' }).getAttribute('href')).toBe('https://repo');
+  });
+});

--- a/tests/components.test.ts
+++ b/tests/components.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { Header } from '../src/app/components';
+import { Header, BookmarkList } from '../src/app/components';
 
 describe('component exports', () => {
   it('re-exports Header', () => {
     expect(Header).toBeDefined();
+  });
+
+  it('re-exports BookmarkList', () => {
+    expect(BookmarkList).toBeDefined();
   });
 });


### PR DESCRIPTION
## Context
- create a minimal portal homepage
- expose a BookmarkList component for listing bookmarks

## Changes
- replace default Next.js template with simple header and bookmark list
- add `BookmarkList` component and tests
- export new component via barrel

## Testing Done
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_688149a1598c832689a069d6e044a99b

## Summary by Sourcery

Replace default Next.js template with a simplified portal homepage that uses a Header and BookmarkList component

New Features:
- Add BookmarkList component to render a list of bookmarks and export it via barrel
- Replace the default landing page with a Portal homepage featuring the Header and BookmarkList
- Define example bookmarks array on the homepage for demonstration

Tests:
- Add unit tests for the BookmarkList component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Bookmark List component to display bookmarks with visit counts.
  * Simplified the homepage to show a header and the new bookmark list.

* **Tests**
  * Added tests to verify correct rendering of the bookmark list and its export.

* **Refactor**
  * Streamlined the main page layout for improved clarity and focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->