### PR TITLE
[Docs] add contribution and architecture guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to Karakeep Home Portal
+
+Thank you for your interest in improving the project! This guide explains how to get started and the expectations for new contributions.
+
+## Development Setup
+
+1. Install dependencies with **Yarn**:
+   ```bash
+   yarn install
+   ```
+2. Start the development server:
+   ```bash
+   yarn dev
+   ```
+3. Run tests and lint checks before submitting a pull request:
+   ```bash
+   yarn lint
+   yarn test
+   ```
+
+## Coding Standards
+
+- Use **TypeScript** exclusively; avoid `any` unless absolutely necessary.
+- Follow the existing project structure:
+  - Components live under `src/app/components`.
+  - Typed helpers belong in `lib/`.
+  - Tests reside in `tests/` and must cover every public interface.
+- Adhere to the lint and format rules. Run `yarn lint` and `yarn format` to automatically fix issues.
+- Write JSDoc comments for all exported functions and components.
+
+## Commit and PR Guidelines
+
+- Commit messages follow **Conventional Commits** (e.g. `feat(bookmarks): add favorite filter`).
+- Pull request titles use prefixes `[Feat]`, `[Fix]`, `[Chore]`, or `[Docs]`.
+- Include context, a summary of changes, and testing evidence in the PR description.
+- Target the `main` branch and ensure `yarn lint` and `yarn test` pass in CI.
+
+For more in-depth rules, see `AGENTS.md` in the repository root.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,23 @@
+# Architecture Overview
+
+This document explains how data flows through the Karakeep Home Portal and maps to the project structure described in `AGENTS.md`.
+
+## Directory Structure
+
+| Path | Purpose |
+| --- | --- |
+| `app/` | Next.js App Router entry (server-first) |
+| `lib/` | Typed helpers (API fetchers, utilities) |
+| `public/` | Static assets |
+| `tests/` | Unit & component tests (Vitest + Testing Library) |
+| `docker/` | Dockerfile and Compose samples |
+| `.github/` | CI workflows |
+
+## Data Flow
+
+1. **Server Components** in `app/` request data from the KaraKeep API using helpers under `lib/`. These helpers validate responses with `zod` before returning typed results.
+2. The data is passed as props to **client components** under `src/app/components`. Components remain stateless and focus on rendering.
+3. Client components may fetch additional data with SWR when necessary, but the preferred approach is to fetch on the server.
+4. Tests in `tests/` verify component output and exported helpers, maintaining ≥ 90 % coverage.
+
+The portal is designed for read-only access, so no user data is stored locally. All API keys are supplied at runtime via Docker secrets.


### PR DESCRIPTION
## Context
`AGENTS.md` references documentation files that were missing in the repo.

## Changes
- add `CONTRIBUTING.md` with contribution instructions
- add `docs/ARCHITECTURE.md` detailing project structure and data flow

## Testing Done
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68821585d8ec8326b8b0b928cd20946e

## Summary by Sourcery

Add new documentation files to guide contributors and explain project architecture

Documentation:
- Add CONTRIBUTING.md with setup instructions, coding standards, and PR guidelines
- Add docs/ARCHITECTURE.md detailing directory structure and data flow through the portal