### PR TITLE
[Docs] add contributing and architecture guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to Karakeep Home Portal
+
+Thank you for helping improve the portal! Follow these guidelines to keep the codebase consistent and easy to maintain.
+
+## Getting Started
+
+1. Fork the repository and create a feature branch.
+2. Install dependencies with `yarn install`.
+3. Start the dev server using `yarn dev`.
+
+## Commit Style
+
+- Use **Conventional Commits** for all messages.
+- Run `yarn lint` and `yarn test` before committing; both must pass.
+- Commits should be small and focused.
+
+## Pull Requests
+
+1. Prefix the title with `[Feat]`, `[Fix]`, `[Chore]` or `[Docs]`.
+2. Describe the context, changes and testing done.
+3. Ensure coverage stays above 90%.
+4. Target the `main` branch.
+
+## Coding Conventions
+
+- TypeScript only; avoid `any` unless wrapped with `@ts-expect-error`.
+- Components should be functional and stateless.
+- Use Tailwind CSS classes for styling.
+
+For a deeper dive into how data flows through the app, see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).

--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ code --folder-uri "vscode-remote://dev-container+$(pwd)"
 ```
 
 The container exposes port `3000` to run the Next.js server.
+
+## Project Documentation
+
+| File | Purpose |
+| ---- | ------- |
+| `README.md` | Quick start and commands |
+| `AGENTS.md` | Agent guide and coding conventions |
+| `CONTRIBUTING.md` | How to contribute to the project |
+| `docs/ARCHITECTURE.md` | Data flow overview |
+| `src/app/components/codex.md` | Component-level rules |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,18 @@
+# Karakeep Home Portal Architecture
+
+This document explains how data flows through the portal. The table below lists the key directories.
+
+| Path | Purpose |
+| ---- | ------- |
+| `app/` | Next.js App Router entry. Server components live here. |
+| `lib/` | Typed helpers for API access (future). |
+| `public/` | Static assets served as-is. |
+| `tests/` | Unit and component tests. |
+
+## Data Flow
+
+1. **Server Load** – `app/page.tsx` fetches bookmark data from the Karakeep API using helpers in `lib/`.
+2. **Rendering** – Fetched data is passed to stateless React components like `BookmarkList`.
+3. **Client Interaction** – Components are rendered on the client with no additional state; SWR would handle client fetches if needed.
+
+The design keeps logic on the server and components purely presentational.


### PR DESCRIPTION
## Context
The AGENTS guide references `CONTRIBUTING.md` and `docs/ARCHITECTURE.md`, but the files were missing.

## Changes
- added contribution guidelines
- documented portal data flow under `docs/`
- linked new docs in README

## Testing Done
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6882190a86988326a4b86675d1949a4d

## Summary by Sourcery

Add contributing and architecture guides to the repository and link them in the README

Documentation:
- Add CONTRIBUTING.md with project contribution guidelines and commit conventions
- Add docs/ARCHITECTURE.md outlining the portal's data flow and directory structure
- Update README.md to include a Project Documentation section linking to the new guides