### PR TITLE
[Chore] ensure setup before lint and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,7 @@ jobs:
           node-version: 20
           cache: 'yarn'
       - name: Install dependencies
-        run: |
-          corepack enable
-          yarn install --immutable --mode=skip-build
+        run: corepack yarn setup
       - name: Lint
         run: yarn lint
       - name: Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for helping improve the portal! Follow these guidelines to keep the co
 ## Getting Started
 
 1. Fork the repository and create a feature branch.
-2. Install dependencies with `yarn install`.
+2. Install dependencies with `yarn setup` (runs `corepack enable && yarn install`).
 3. Start the dev server using `yarn dev`.
 
 ## Commit Style

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Lightweight, read-only dashboard for your Karakeep bookmarks and stats. Built wi
 
 ## Local Development
 
-Install dependencies and start the development server:
+Install dependencies with Corepack and start the development server:
 
 ```bash
-yarn install
+yarn setup
 yarn dev
 ```
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
+    "setup": "corepack enable && yarn install --immutable --mode=skip-build",
+    "prelint": "yarn setup",
     "lint": "next lint",
+    "pretest": "yarn setup",
     "test": "vitest run --environment jsdom"
   },
   "dependencies": {


### PR DESCRIPTION
## Context
Linting and test runs could fail if dependencies were not installed first.

## Changes
- add `setup` script running `corepack` and `yarn install`
- call `setup` before `lint` and `test`
- update docs with new command
- update CI to use `corepack yarn setup`

## Testing Done
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68822af829a883269b96729c533474f3

## Summary by Sourcery

Introduce a dedicated 'setup' script to install dependencies via Corepack and enforce its execution before linting and testing both locally and in CI, updating documentation and workflows accordingly.

Enhancements:
- Add 'setup' script to enable Corepack and install dependencies and hook it into prelint and pretest commands

CI:
- Update CI workflow to replace manual dependency installation with 'corepack yarn setup'

Documentation:
- Revise README and CONTRIBUTING.md to instruct users to run 'yarn setup' for dependency installation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation instructions in documentation to use Corepack via a new setup command.
  * Introduced a setup script to streamline dependency installation, ensuring Corepack is enabled before installing packages.
  * Automated the setup process to run before linting and testing commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->