### PR TITLE
[Chore] add jest-dom matchers

### DIFF
--- a/tests/BookmarkList.test.tsx
+++ b/tests/BookmarkList.test.tsx
@@ -10,7 +10,19 @@ describe('BookmarkList', () => {
       { title: 'Repo', url: 'https://repo', visits: 2 },
     ];
     render(<BookmarkList bookmarks={bookmarks} />);
-    expect(screen.getByRole('link', { name: 'Docs (1)' }).getAttribute('href')).toBe('https://docs');
-    expect(screen.getByRole('link', { name: 'Repo (2)' }).getAttribute('href')).toBe('https://repo');
+    expect(
+      screen.getByRole('link', { name: 'Docs (1)' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Docs (1)' })).toHaveAttribute(
+      'href',
+      'https://docs'
+    );
+    expect(
+      screen.getByRole('link', { name: 'Repo (2)' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Repo (2)' })).toHaveAttribute(
+      'href',
+      'https://repo'
+    );
   });
 });

--- a/tests/Header.test.tsx
+++ b/tests/Header.test.tsx
@@ -6,6 +6,8 @@ import Header from '../src/app/components/Header';
 describe('Header', () => {
   it('renders the heading text', () => {
     render(<Header title="Portal" />);
-    expect(screen.getByRole('heading', { name: 'Portal 🎉' })).toBeTruthy();
+    expect(
+      screen.getByRole('heading', { name: 'Portal 🎉' })
+    ).toBeInTheDocument();
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom/vitest'
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    setupFiles: './tests/setup.ts',
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],


### PR DESCRIPTION
## Context
Need improved Testing Library assertions.

## Changes
- register `@testing-library/jest-dom` in Vitest setup
- verify DOM elements using `toBeInTheDocument` and `toHaveAttribute`

## Testing Done
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68822eb53c108326a4463eb7d84475fd

## Summary by Sourcery

Add jest-dom matchers to Vitest setup and update tests to use improved DOM assertions

Enhancements:
- Register @testing-library/jest-dom in Vitest setup file

Tests:
- Refactor BookmarkList and Header tests to use toBeInTheDocument and toHaveAttribute matchers instead of manual attribute checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test assertions for bookmark links and header components to explicitly check for DOM presence and correct attributes.
  * Introduced a global test setup file to enable improved DOM matchers in tests.
  * Updated test configuration to automatically load the setup file before running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->